### PR TITLE
Fix accessibility settings update

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -133,7 +133,10 @@ function AccessibilitySettings() {
     document.documentElement.classList.toggle('large-text', data.largeText);
     
     // Update accessibility service
-    accessibilityService.updatePreferences({
+    accessibilityService.updateSettings({
+      reduceMotion: data.reduceMotion,
+      highContrast: data.highContrast,
+      fontSize: data.largeText ? 'large' : 'normal',
       screenReaderOptimized: data.screenReaderOptimized,
       keyboardNavigation: data.keyboardNavigation,
     });


### PR DESCRIPTION
## Summary
- call `updateSettings` from AccessibilityService instead of `updatePreferences`
- map form values to `AccessibilitySettings` fields when saving

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685073aed07083328dc88e86948f2398